### PR TITLE
Implement progress tracking context and theme

### DIFF
--- a/AI_CONTRIB_LOG.yaml
+++ b/AI_CONTRIB_LOG.yaml
@@ -1,1 +1,2 @@
 # AI contribution and audit log (auto-updated)
+- 2025-06-24: Added progress tracking context and Tailwind theming

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Transforming from technical foundations to AI leadership through structured lear
 - **📱 Mobile Responsive**: Optimized for all device sizes
 - **🔗 Resource Type Icons**: Visual indicators for courses, books, tutorials, and more
 - **🏁 Checkpoint System**: Clear milestones and deliverable tracking
+- **🔄 Local Progress Context**: Personal progress stored privately in your browser
 - **💡 Learning Rationale**: "Why this matters" context for each milestone
 
 Explore the complete roadmap with progress tracking, detailed descriptions, and milestone checkpoints

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,1 @@
+# Personal Learning Content

--- a/docs/AGENTS/feature_plan.md
+++ b/docs/AGENTS/feature_plan.md
@@ -29,7 +29,7 @@ Transform the `ai-engineering-roadmap` repository into a modern, interactive per
   - Integrate TailwindCSS for UI
   - Commit: "Scaffold Next.js project with TypeScript and TailwindCSS"
 
-- [ ] **Organize directories for personal learning**
+- [x] **Organize directories for personal learning**
   ```
   /content/      # Markdown/YAML learning nodes and resources
   /assets/       # Images, diagrams, screenshots
@@ -40,11 +40,11 @@ Transform the `ai-engineering-roadmap` repository into a modern, interactive per
   ```
   - Commit: "Restructure repository for personal learning organization"
 
-- [ ] **Set up IndexedDB/localStorage for progress tracking**
+- [x] **Set up IndexedDB/localStorage for progress tracking**
   - Bootstrapped with React Context
   - Commit: "Add local storage for progress tracking"
 
-- [ ] **Add enhanced global CSS**
+- [x] **Add enhanced global CSS**
   - Tailwind configuration, brand-aligned custom theme, dark/light mode
   - Commit: "Add enhanced CSS and theming"
 

--- a/frontend-next/README.md
+++ b/frontend-next/README.md
@@ -18,6 +18,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+### Progress Tracking
+
+Learning progress is stored locally using `localStorage`. Wrap your pages with `ProgressProvider` from `src/context/ProgressContext` and use the `useProgress` hook to read or update progress values.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/frontend-next/src/app/globals.css
+++ b/frontend-next/src/app/globals.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;
@@ -20,7 +22,5 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  @apply bg-background text-foreground font-sans;
 }

--- a/frontend-next/src/app/layout.tsx
+++ b/frontend-next/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ProgressProvider } from "../context/ProgressContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +25,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ProgressProvider>{children}</ProgressProvider>
       </body>
     </html>
   );

--- a/frontend-next/src/app/page.tsx
+++ b/frontend-next/src/app/page.tsx
@@ -1,8 +1,11 @@
 import Image from "next/image";
+import { useProgress } from "../context/ProgressContext";
 
 export default function Home() {
+  const { progress, setProgress } = useProgress();
+
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-sans">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
@@ -24,6 +27,13 @@ export default function Home() {
             Save and see your changes instantly.
           </li>
         </ol>
+
+        <button
+          className="mt-4 px-4 py-2 bg-brand text-white rounded"
+          onClick={() => setProgress("intro", (progress["intro"] ?? 0) + 1)}
+        >
+          Complete Intro ({progress["intro"] ?? 0})
+        </button>
 
         <div className="flex gap-4 items-center flex-col sm:flex-row">
           <a

--- a/frontend-next/src/context/ProgressContext.tsx
+++ b/frontend-next/src/context/ProgressContext.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export interface ProgressState {
+  [key: string]: number;
+}
+
+interface ProgressContextProps {
+  progress: ProgressState;
+  setProgress: (id: string, value: number) => void;
+}
+
+const ProgressContext = createContext<ProgressContextProps | undefined>(undefined);
+
+export const ProgressProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [progress, setProgressState] = useState<ProgressState>({});
+
+  useEffect(() => {
+    const stored = localStorage.getItem("progress");
+    if (stored) {
+      setProgressState(JSON.parse(stored));
+    }
+  }, []);
+
+  const setProgress = (id: string, value: number) => {
+    setProgressState((prev) => {
+      const updated = { ...prev, [id]: value };
+      localStorage.setItem("progress", JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  return (
+    <ProgressContext.Provider value={{ progress, setProgress }}>
+      {children}
+    </ProgressContext.Provider>
+  );
+};
+
+export const useProgress = (): ProgressContextProps => {
+  const ctx = useContext(ProgressContext);
+  if (!ctx) {
+    throw new Error("useProgress must be used within ProgressProvider");
+  }
+  return ctx;
+};

--- a/frontend-next/tailwind.config.mjs
+++ b/frontend-next/tailwind.config.mjs
@@ -1,0 +1,25 @@
+/** @type {import('tailwindcss').Config} */
+const config = {
+  darkMode: 'class',
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: 'var(--font-sans)',
+        mono: 'var(--font-mono)',
+      },
+      colors: {
+        brand: {
+          light: '#7dd3fc',
+          DEFAULT: '#0284c7',
+          dark: '#0369a1',
+        },
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add local progress context for Next.js frontend
- extend Tailwind config and global CSS
- wrap layout with ProgressProvider and add sample usage
- document progress tracking in README files
- update feature plan with completed tasks

## Testing
- `scripts/validate_pr.sh` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6859f3ea3b08832c902bf91fa2565e88