### PR TITLE
Fix backend test imports and requests typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ All notable changes to this project will be documented in this file.
 
 - Code of Conduct
 - Changelog
+- requests dependency for Ollama integration
+- types-requests stubs for mypy
 
 ### Fixed
 
 - Placeholder for future release notes
+- test import path for backend src
 
 ## [0.1.0] - 2023-10-01
 

--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -32,3 +32,4 @@ factory-boy>=3.3.0
 # Security Testing
 bandit>=1.7.5
 safety>=2.3.0
+types-requests>=2.32.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,4 @@ redis>=5.0.0
 
 # Environment & Configuration
 python-dotenv>=1.0.0
+requests>=2.31.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,13 @@
 """Test configuration and fixtures."""
 
+import sys
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
+
+# Ensure src is on the path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from src.main import app
 


### PR DESCRIPTION
## Summary
- add requests dependency and stub types for mypy
- ensure backend tests add src to path
- document dependency updates in CHANGELOG

## Testing
- `scripts/validate_pr.sh`

------
https://chatgpt.com/codex/tasks/task_e_685fad851514832ca96ea803abb273bc