### PR TITLE
Implement Ollama sync integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Transforming from technical foundations to AI leadership through structured lear
 - **🔗 Resource Type Icons**: Visual indicators for courses, books, tutorials, and more
 - **🏁 Checkpoint System**: Clear milestones and deliverable tracking
 - **💡 Learning Rationale**: "Why this matters" context for each milestone
-- **🦙 Ollama Integration**: Status card and evening assistant components for local model interaction
+- **🦙 Ollama Integration**: Status card and evening assistant components that sync with the backend `/ollama/sync` API
 
 Explore the complete roadmap with progress tracking, detailed descriptions, and milestone checkpoints
 

--- a/backend/src/integrations/providers/ollama.py
+++ b/backend/src/integrations/providers/ollama.py
@@ -3,15 +3,32 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass, field
 
+# Default Ollama API configuration
+from typing import Any
+
 import requests
+
+OLLAMA_API: dict[str, Any] = {
+    "base": "http://localhost:11434",
+    "endpoints": {
+        "generate": "/api/generate",
+        "chat": "/api/chat",
+        "pull": "/api/pull",
+        "list": "/api/tags",
+        "running": "/api/ps",
+    },
+}
 
 
 @dataclass
 class RoadmapConfig:
+    """Configuration for the current roadmap progress."""
+
     current_week: int
 
 
 def _default_schedule() -> dict[int, list[str]]:
+    """Return default mapping of weeks to required Ollama models."""
     return {
         1: ["python-tutor:latest", "codellama:7b-python"],
         2: ["codellama:7b", "mistral:latest"],
@@ -25,27 +42,33 @@ class OllamaIntegrationService:
     """Sync Ollama models with the current roadmap week."""
 
     roadmap: RoadmapConfig
-    api_base: str = "http://localhost:11434"
+    api_base: str = OLLAMA_API["base"]
     schedule: dict[int, list[str]] = field(default_factory=_default_schedule)
     active_model: str | None = None
     sync_status: str = "pending"
 
     async def check_ollama_installed(self) -> bool:
+        """Return True if the Ollama CLI is available on the system."""
         return shutil.which("ollama") is not None
 
     def get_required_models(self, week: int) -> list[str]:
+        """Get the models required for the given week."""
         return self.schedule.get(week, ["mistral:latest"])
 
     async def pull_model(self, model_name: str) -> None:
+        """Request Ollama to pull the specified model."""
         requests.post(f"{self.api_base}/api/pull", json={"name": model_name})
 
     async def set_active_model(self, model_name: str) -> None:
+        """Mark the given model as active."""
         self.active_model = model_name
 
     async def update_sync_status(self, status: str) -> None:
+        """Update the sync status value."""
         self.sync_status = status
 
     async def sync_with_roadmap(self) -> None:
+        """Pull models for the current week and update status."""
         if not await self.check_ollama_installed():
             await self.update_sync_status("error")
             return

--- a/backend/src/services/roadmap_sequence.py
+++ b/backend/src/services/roadmap_sequence.py
@@ -9,11 +9,13 @@ from typing import Any, cast
 
 
 def _load_json(path: Path) -> dict[str, Any]:
+    """Load JSON data from a file path."""
     with path.open("r", encoding="utf-8") as f:
         return cast(dict[str, Any], json.load(f))
 
 
 def _save_json(path: Path, data: dict[str, Any]) -> None:
+    """Save JSON data to a file path."""
     with path.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
@@ -25,25 +27,30 @@ class RoadmapSequenceFixer:
     config_path: Path
 
     async def backup_current_progress(self) -> None:
+        """Create a backup of the current roadmap configuration."""
         backup = self.config_path.with_suffix(self.config_path.suffix + ".bak")
         shutil.copy(self.config_path, backup)
 
     async def load_config(self) -> dict[str, Any]:
+        """Load roadmap configuration from disk."""
         return _load_json(self.config_path)
 
     def reorder_phases(self, phases: dict[str, Any]) -> dict[str, Any]:
-        # Sort phases by their declared order key
+        """Return phases ordered by their ``order`` field."""
         return dict(sorted(phases.items(), key=lambda kv: kv[1].get("order", 0)))
 
     def calculate_current_week(self) -> int:
+        """Calculate the current week number from the start date."""
         start = date(2025, 6, 21)
         delta = date.today() - start
         return delta.days // 7 + 1
 
     async def save_config(self, config: dict[str, Any]) -> None:
+        """Persist the updated configuration to disk."""
         _save_json(self.config_path, config)
 
     async def fix_sequence(self) -> None:
+        """Reorder roadmap phases and update the current week."""
         await self.backup_current_progress()
         config = await self.load_config()
         config["phases"] = self.reorder_phases(config.get("phases", {}))

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -19,3 +19,35 @@ def test_health_check_endpoint(client: TestClient):
     data = response.json()
     assert data["status"] == "healthy"
     assert data["service"] == "brainwav-backend"
+
+
+def test_ollama_sync_endpoint(client: TestClient, monkeypatch):
+    """Ensure the /ollama/sync endpoint triggers model sync."""
+
+    async def fake_sync(self) -> None:
+        self.sync_status = "synced"
+        self.active_model = "python-tutor:latest"
+
+    monkeypatch.setattr(
+        "src.main.OllamaIntegrationService.sync_with_roadmap", fake_sync
+    )
+
+    response = client.post("/ollama/sync")
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "synced",
+        "activeModel": "python-tutor:latest",
+    }
+
+
+def test_fix_sequence_endpoint(client: TestClient, monkeypatch):
+    """Ensure the /roadmap/fix-sequence endpoint updates roadmap data."""
+
+    async def fake_fix(self) -> None:
+        pass
+
+    monkeypatch.setattr("src.main.RoadmapSequenceFixer.fix_sequence", fake_fix)
+
+    response = client.post("/roadmap/fix-sequence")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/frontend-next/src/components/OllamaStatusCard.tsx
+++ b/frontend-next/src/components/OllamaStatusCard.tsx
@@ -5,8 +5,15 @@ import { motion } from "framer-motion";
 import { CheckCircle, AlertCircle, Loader2, Terminal } from "lucide-react";
 
 const checkOllamaSync = async () => {
-  // placeholder check implementation
-  return { status: "synced", activeModel: "mistral:latest", progress: {} };
+  const res = await fetch("http://localhost:8000/ollama/sync", {
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    throw new Error("Sync failed");
+  }
+
+  return res.json();
 };
 
 export const OllamaStatusCard = () => {

--- a/frontend-next/src/components/__tests__/OllamaStatusCard.integration.test.tsx
+++ b/frontend-next/src/components/__tests__/OllamaStatusCard.integration.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { OllamaStatusCard } from "../OllamaStatusCard";
+
+
+describe("OllamaStatusCard integration", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ status: "synced", activeModel: "mistral:latest", progress: {} }),
+      })
+    );
+  });
+
+  it("fetches sync status on mount", async () => {
+    render(<OllamaStatusCard />);
+    expect(global.fetch).toHaveBeenCalledWith("http://localhost:8000/ollama/sync", { method: "POST" });
+    await waitFor(() => expect(screen.getByText("Synced")).toBeInTheDocument());
+    expect(screen.getByText("mistral:latest")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `OLLAMA_API` config and docstrings for providers and roadmap services
- call backend sync API in `OllamaStatusCard`
- verify endpoints with new backend tests
- test status card fetching with Jest
- document backend sync in README

## Testing
- `scripts/validate_pr.sh`
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686085eabf14832c92db93a337555ce1